### PR TITLE
Handle Tokens Larger Than Line Size

### DIFF
--- a/src/ShortestPath.js
+++ b/src/ShortestPath.js
@@ -65,7 +65,7 @@ function getBestFit(tokens, spaceSize, offsets, width, height, fontSize, lineHei
         for (let i = 0; i < count; i++) {
             let j = i + 1
             while (j <= count) {
-                let w = offsets[j] - offsets[i] + (j - i) *spaceSize
+                let w = offsets[j] - offsets[i] + (j - i - 1) *spaceSize
                 let cost
                 if (w > scaledWidth) {
                     break

--- a/src/ShortestPath.js
+++ b/src/ShortestPath.js
@@ -101,6 +101,11 @@ function getBestFit(tokens, spaceSize, offsets, width, height, fontSize, lineHei
         maxLineWidth = currentLines * width/heightRatio
         results = findMinima(maxLineWidth, currentLines)
 
+        if (attempts > 100) {
+            throw new Error(`Can't fit text after ${attempts} attempts`);
+        }
+        attempts++
+
         if (!results) {
             currentLines++
         } else {

--- a/src/index.js
+++ b/src/index.js
@@ -188,9 +188,22 @@ class AutoFittingText extends ReactiveClass {
     offsets[0] = 0
     for (let i = 0; i < this.tokens.length; i++) {
       const token = this.tokens[i]
-      offsets[i + 1] = offsets[i] + this.context.measureText(token).width
+      const tokenWidth = this.context.measureText(token).width
+      offsets[i + 1] = offsets[i] + tokenWidth
+      this._maxTokenSize = Math.max(this._maxTokenSize || 0, tokenWidth)
     }
     return offsets
+  }
+
+  /**
+   * The biggest token size of current targetString
+   * @return {Number} - the largest token size using current fontFamily
+   */
+  get maxTokenSize () {
+    if (this.offsets) {
+      return this._maxTokenSize
+    }
+    return 0
   }
 
   /**
@@ -206,7 +219,8 @@ class AutoFittingText extends ReactiveClass {
       this.width,
       this.height,
       this.fontMetricsSize,
-      this.lineHeight
+      this.lineHeight,
+      this.maxTokenSize
     )
 
     const lines = bestFit.results.map(({line}) => line)


### PR DESCRIPTION
* Keep track of maxTokenSize (the largest token rendered in the target string).
* Use the maxTokenSize to start calculating minimum number of required lines to fit, which should address https://github.com/Xanderite/fontfill/issues/2.
* Don't count spaces at end of lines in weight calculation (they shouldn't be there).
* Add a check to make sure an infinite loop occurs when fitting text.