### PR TITLE
Hotfix/tighter fitting minimum fontsize

### DIFF
--- a/src/ShortestPath.js
+++ b/src/ShortestPath.js
@@ -102,6 +102,10 @@ function getBestFit(tokens, spaceSize, offsets, width, height, fontSize, lineHei
         return line.slice(0, j - 1) + truncatedToken
     }
 
+    function calcWidth(i, j) {
+        return offsets[j] - offsets[i] + 1 + (j - i - 1) * spaceSize // there is a plus one to avoid rounding errors
+    }
+
     function findMinima(scaledWidth, targetLines) {
         let minima = [0].concat(fillArray(Array(count), Infinity))
         let breaks = fillArray(Array(count + 1), 0)
@@ -109,7 +113,7 @@ function getBestFit(tokens, spaceSize, offsets, width, height, fontSize, lineHei
         for (let i = 0; i < count; i++) {
             let j = i + 1
             while (j <= count) {
-                let w = offsets[j] - offsets[i] + (j - i - 1) *spaceSize
+                let w = calcWidth(i, j)
                 if (w > scaledWidth) {
                     break
                 }
@@ -135,7 +139,7 @@ function getBestFit(tokens, spaceSize, offsets, width, height, fontSize, lineHei
             } else {
                 lineIndexes.push({ start: i, end: j })
             }
-            let width = offsets[j] - offsets[i] + (j - i) * spaceSize
+            let width = calcWidth(i, j)
             largestLineSize = Math.max(largestLineSize, width)
             j = i
         }
@@ -180,7 +184,7 @@ function getBestFit(tokens, spaceSize, offsets, width, height, fontSize, lineHei
             let i = breaks[j]
             lineIndexes.push({ start: i, end: j + 1 })
 
-            let width = offsets[j] - offsets[i] + (j - i) * spaceSize
+            let width = calcWidth(i, j)
             largestLineSize = Math.max(largestLineSize, width)
 
             j = i
@@ -188,7 +192,7 @@ function getBestFit(tokens, spaceSize, offsets, width, height, fontSize, lineHei
             while (j > 0) {
                 let i = breaks[j]
                 lineIndexes.push({ start: i, end: j })
-                let width = offsets[j] - offsets[i] + (j - i) * spaceSize
+                let width = calcWidth(i, j)
                 largestLineSize = Math.max(largestLineSize, width)
                 j = i
             }

--- a/src/ShortestPath.js
+++ b/src/ShortestPath.js
@@ -85,6 +85,7 @@ function getBestFit(tokens, spaceSize, offsets, width, height, fontSize, lineHei
             }
         }
     }
+
     let minLines = i
 
     // make sure min lines isn't greater than max lines
@@ -124,6 +125,7 @@ function getBestFit(tokens, spaceSize, offsets, width, height, fontSize, lineHei
     function findMinima(scaledWidth, targetLines) {
         let minima = [0].concat(fillArray(Array(count), Infinity))
         let breaks = fillArray(Array(count + 1), 0)
+
         largestLineSize = 0
         for (let i = 0; i < count; i++) {
             let j = i + 1

--- a/src/ShortestPath.js
+++ b/src/ShortestPath.js
@@ -161,10 +161,6 @@ function getBestFit(tokens, spaceSize, offsets, width, height, fontSize, lineHei
 
         const truncate = maxLines && (lineIndexes.length > maxLines) && (targetLines === maxLines)
 
-        if (truncate) {
-            lineIndexes = lineIndexes.slice(lineIndexes.length - maxLines, lineIndexes.length)
-        }
-
         function countLinesFromBreaks (nextBreak) {
             let lineCount = 0
 

--- a/src/index.js
+++ b/src/index.js
@@ -311,7 +311,7 @@ class AutoFittingText extends ReactiveClass {
     if (targetLines > lines.length) {
       let widthRatio = bestFit.maxLineWidth / bestFit.largestLineSize
       let heightRatio = targetLines / lines.length
-      fillRatio = Math.min(widthRatio, heightRatio)
+      fillRatio = roundDown(Math.min(widthRatio, heightRatio))
     }
 
     let fontSize


### PR DESCRIPTION
## Hotfixes
* Avoid rounding errors by adding +1 to calculated width
* Add logic to scale width correctly if minimum font size forces an unwhole number of lines
* Round down fill ratio before scaling font size
## Other
* Add some white space for tidier code
* Encapsulate width calculation into a function